### PR TITLE
Increased request timeout from 30 to 120 seconds

### DIFF
--- a/app/util/api/abstract_clients.py
+++ b/app/util/api/abstract_clients.py
@@ -39,7 +39,7 @@ class RestClient(Client):
     def to_json(obj: dict) -> str:
         return json.dumps(obj)
 
-    def __init__(self, host, user, password, session=None, timeout=30):
+    def __init__(self, host, user, password, session=None, timeout=120):
         super().__init__(host, user, password)
 
         self._requests_timeout = timeout


### PR DESCRIPTION
This PR increases the timeout of the request what helps in running DCAPT tests on Bamboo. Before this change the builds were failing in the flaky way. 
With this change the build started to execute properly on Bamboo.
Locally, I was not able to reproduce the issue with flakiness.